### PR TITLE
[feat] todo, base 엔티티 개발 완료

### DIFF
--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/entity/Base.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/entity/Base.java
@@ -1,0 +1,26 @@
+package com.siillvergun.todolist.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.cglib.core.Local;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(value = AuditingEntityListener.class)
+public class Base {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    protected LocalDateTime created_at;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", updatable = false)
+    protected LocalDateTime updated_at;
+    protected Boolean is_deleted;
+}

--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/todo/entity/Todo.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/todo/entity/Todo.java
@@ -1,0 +1,22 @@
+package com.siillvergun.todolist.todo.entity;
+
+import com.siillvergun.todolist.global.entity.Base;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Entity
+@Table(name = "todo")
+public class Todo extends Base {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "category", nullable = false)
+    private String category;
+}


### PR DESCRIPTION
1. base엔티티에 생성일, 수정일 등 공통으로 들어가는 필드 추가
2. ERD를 기준으로 base 엔티티를 상속받는 todo 엔티티 생성