### PR TITLE
[refactor] 마감일 검증 오류 및 dto-entity 변환 위치

### DIFF
--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/exception/CustomError.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/exception/CustomError.java
@@ -1,4 +1,4 @@
-package com.siillvergun.todolist.global.error;
+package com.siillvergun.todolist.global.exception;
 
 import lombok.Getter;
 

--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/exception/ErrorCode.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/exception/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.siillvergun.todolist.global.error;
+package com.siillvergun.todolist.global.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/exception/GlobalExceptionHandler.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,6 @@
-package com.siillvergun.todolist.global.error;
+package com.siillvergun.todolist.global.exception;
 
-import com.siillvergun.todolist.global.error.dto.ErrorResponseDto;
+import com.siillvergun.todolist.global.exception.dto.ErrorResponseDto;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/exception/dto/ErrorResponseDto.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/global/exception/dto/ErrorResponseDto.java
@@ -1,6 +1,6 @@
-package com.siillvergun.todolist.global.error.dto;
+package com.siillvergun.todolist.global.exception.dto;
 
-import com.siillvergun.todolist.global.error.ErrorCode;
+import com.siillvergun.todolist.global.exception.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/todo/dto/TodoRequestDto.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/todo/dto/TodoRequestDto.java
@@ -2,7 +2,7 @@ package com.siillvergun.todolist.todo.dto;
 
 import com.siillvergun.todolist.todo.entity.Category;
 import com.siillvergun.todolist.todo.entity.Todo;
-import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -17,9 +17,9 @@ public class TodoRequestDto {
     @NotBlank(message = "내용은 필수 입니다")
     private String content;
     @NotNull
-    @Future(message = "마감일은 현재 이후여야 합니다")
+    @FutureOrPresent(message = "마감일은 과거이면 안됍니다.")
     private LocalDate dueDate;
-    
+
     @NotNull(message = "정해진 카테고리만 사용할 수 있습니다.")
     private Category category;
 

--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/todo/dto/TodoUpdateRequestDto.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/todo/dto/TodoUpdateRequestDto.java
@@ -1,7 +1,7 @@
 package com.siillvergun.todolist.todo.dto;
 
 import com.siillvergun.todolist.todo.entity.Category;
-import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -15,7 +15,7 @@ public class TodoUpdateRequestDto {
     @NotBlank(message = "내용은 필수 입니다")
     private String content;
     @NotNull
-    @Future(message = "마감일은 현재 이후여야 합니다")
+    @FutureOrPresent(message = "마감일은 과거이면 안됍니다.")
     private LocalDate dueDate;
     @NotNull(message = "정해진 카테고리만 사용할 수 있습니다.")
     private Category category;

--- a/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/todo/service/TodoService.java
+++ b/gunsilver/appcenter-todo-api/src/main/java/com/siillvergun/todolist/todo/service/TodoService.java
@@ -1,7 +1,7 @@
 package com.siillvergun.todolist.todo.service;
 
-import com.siillvergun.todolist.global.error.CustomError;
-import com.siillvergun.todolist.global.error.ErrorCode;
+import com.siillvergun.todolist.global.exception.CustomError;
+import com.siillvergun.todolist.global.exception.ErrorCode;
 import com.siillvergun.todolist.todo.dto.TodoRequestDto;
 import com.siillvergun.todolist.todo.dto.TodoResponseDto;
 import com.siillvergun.todolist.todo.dto.TodoUpdateRequestDto;


### PR DESCRIPTION
1. 마감일이 현재이면 @Future 검증 조건 떄문에 에러가 나던걸 @FutureOrPresent로 바꿔 오늘도 포함되게 수정
2. dto-entity 변환 위치
dto-entity 변환 로직 위치는 각 레이어의 의존관계를 봐야함. 
여기서 중요한 점은 상위 레이어는 하위 레이어를 볼 수 있지만 그 반대는 안됨. 
추가로 상위 레이어라도 2단게 이상의 하위 레이어를 보는 것은 잘못된 설계. 
변환 로직 자체는 dto에 두고 서비스 단에서 참조할 건지 컨트롤러 단에서 참조할 건지 고민. 
서비스 레이어에 변환 로직을 두면 의존관계가 깔끔하지 않는 문제가 발생한다.
컨트롤러 레이어에 두면 의존관게는 깔끔해지지만 단일 책임 원칙 위반이 생기고 코드가 중복되는 문제가 발생.
현재 프로젝트는 단일 Controller 구조이고 규모가 작기 때문에 Service 재사용 가능성이 낮아, 편의성을 위해 Service에서 변환하는 방식을 선택.
만약 프로젝트 크기가 커져 복합 Controller 구조이고 Service 재사용 가능성이 커지면 Controller단에 두거나 별도의 Mapper 클래스를 사용